### PR TITLE
Hente rasteplasser fra SVV

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation ("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.springframework:spring-web:6.0.11")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/example/ruteplanlegger/Controller/RasteplassController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Controller/RasteplassController.kt
@@ -1,15 +1,18 @@
 package com.example.ruteplanlegger.Controller
 
+import com.example.ruteplanlegger.service.RasteplasserService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/rasteplasser")
-class Rasteplasser() {
+class Rasteplasser(val rasteplasserService: RasteplasserService) {
 
     @GetMapping
-    fun getRasteplasser(): String {
-        return "Legg til funksjon for å hente rasteplasser fra repository"
+    fun getRasteplasser(): String? {
+        return rasteplasserService.getAllRasteplasser()
     }
+
+
 }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/RasteplasserService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/RasteplasserService.kt
@@ -1,0 +1,19 @@
+package com.example.ruteplanlegger.service
+
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Service
+class RasteplasserService(val webClient: WebClient.Builder) {
+    fun getAllRasteplasser(): String? {
+        val apiURL = "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39"
+        return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(String::class.java).block()
+        // For liste:
+        //return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(TYPESOMBLIRHENTET::class.java).collectList().block()
+    }
+
+    fun getRasteplassById(): String? {
+        val apiURL = "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39/91203457/6"
+        return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(String::class.java).block()
+    }
+}

--- a/src/main/kotlin/com/example/ruteplanlegger/service/RasteplasserService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/RasteplasserService.kt
@@ -8,10 +8,9 @@ class RasteplasserService(val webClient: WebClient.Builder) {
     fun getAllRasteplasser(): String? {
         val apiURL = "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39"
         return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(String::class.java).block()
-        // For liste:
-        //return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(TYPESOMBLIRHENTET::class.java).collectList().block()
     }
 
+    // TODO: legge til at id blir sendt dynamisk
     fun getRasteplassById(): String? {
         val apiURL = "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39/91203457/6"
         return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(String::class.java).block()


### PR DESCRIPTION
Laget et endepunkt mot SVV sitt API som henter rasteplasser (id: 39). Logikken som går mot et eksternt API skal ligge i en @Service. 

**Forklaring til hvordan webClient funker og hva som egentlig skjer i GET-request kallet**

Nå hentes dataen via en WebClient, som er en moderne (og bedre?) versjon av RestTemplate. Man bygger klienten som gjør det mulig å hente data fra det gitte API-endepunktet med HTTP-requests med build(), så bruker man get() siden det skal være en GET-request. Videre bruker man retrieve() som faktisk henter dataen og gjør den klar for videre prosessering i vår backend. bodyToMono(String::class.java) betyr at man tar responsen over i en "Mono" (som betyr sekvens av data) av typen String i vårt tilfelle. Det vil si at hele resultatet fra vår get-request er en string. block() brukes helt til slutt for å vente på at man har fått all dataen fra endepunktet, før man returnerer funksjonen (funker litt som en await i react). 