### PR TITLE
Fikse cors policy, hente egenskaper og begrense antall objekter vi henter ut

### DIFF
--- a/src/main/kotlin/com/example/ruteplanlegger/Controller/RasteplassController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Controller/RasteplassController.kt
@@ -1,12 +1,14 @@
 package com.example.ruteplanlegger.Controller
 
-import com.example.ruteplanlegger.service.RasteplasserService
+import com.example.ruteplanlegger.Service.RasteplasserService
+import org.springframework.web.bind.annotation.CrossOrigin
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/rasteplasser")
+@CrossOrigin(origins = ["*"])
 class Rasteplasser(val rasteplasserService: RasteplasserService) {
 
     @GetMapping

--- a/src/main/kotlin/com/example/ruteplanlegger/Service/RasteplasserService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Service/RasteplasserService.kt
@@ -1,4 +1,4 @@
-package com.example.ruteplanlegger.service
+package com.example.ruteplanlegger.Service
 
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
@@ -6,7 +6,7 @@ import org.springframework.web.reactive.function.client.WebClient
 @Service
 class RasteplasserService(val webClient: WebClient.Builder) {
     fun getAllRasteplasser(): String? {
-        val apiURL = "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39"
+        val apiURL = "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39?antall=50&inkluder=egenskaper"
         return webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(String::class.java).block()
     }
 


### PR DESCRIPTION
Når vi spesifiserte at vi trengte egenskapene til objektene ble responsen mye større og vi fikk en exeeded buffer limit (husker ikke helt, men noe i den duren). La derfor inn at vi kun skulle hente ut 50 objekter