### PR TITLE
Legge til koordinater på rasteplass

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
     implementation("org.springframework:spring-web:6.0.11")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     implementation("org.json:json:20230227")
+    implementation("org.locationtech.jts:jts-core:1.17.0")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/example/ruteplanlegger/Model/Rasteplass.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Model/Rasteplass.kt
@@ -1,8 +1,19 @@
 package com.example.ruteplanlegger.Model
 
+data class Geometri(
+    val type: String = "Point",
+    val coordinates: LatLong
+)
+
+data class LatLong(
+    val long: Double,
+    var lat: Double
+)
+
 data class Rasteplass(
     val id: Int = 0,
     val navn: String = "",
     val vegkategori: String = "",
     val vegnummer: Int = 0,
+    val geometri: Geometri
 )

--- a/src/main/kotlin/com/example/ruteplanlegger/Service/KunstService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Service/KunstService.kt
@@ -31,7 +31,7 @@ fun createMinimalKunstObject(data: JsonNode): List<Kunst> {
 class KunstService(val webClient: WebClient.Builder) {
     fun getKunstOgUtsmykking(): List<Kunst>? {
         val apiURL =
-            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/19?antall=50&inkluder=egenskaper,vegsegmenter&inkluder_egenskaper=basis&egenskap=(1101!=null)"
+            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/19?antall=50&inkluder=egenskaper,vegsegmenter,geometri&inkluder_egenskaper=basis&egenskap=(1101!=null)&srid=4326"
         val response = webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
         return if (response is JsonNode) createMinimalKunstObject(response) else emptyList()
     }

--- a/src/main/kotlin/com/example/ruteplanlegger/Service/RasteplasserService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Service/RasteplasserService.kt
@@ -38,7 +38,7 @@ fun createMinimalResteplassObject(data: JsonNode): List<Rasteplass> {
 class RasteplasserService(val webClient: WebClient.Builder) {
     fun getAllRasteplasser(): List<Rasteplass>? {
         val apiURL =
-            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39?antall=50&inkluder=vegsegmenter,egenskaper&inkluder_egenskaper=basis"
+            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39?antall=50&inkluder=vegsegmenter,egenskaper,geometri&inkluder_egenskaper=basis&srid=4326"
         val response = webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
         return if (response is JsonNode) createMinimalResteplassObject(response) else emptyList()
     }

--- a/src/main/kotlin/com/example/ruteplanlegger/Service/RasteplasserService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/Service/RasteplasserService.kt
@@ -1,13 +1,31 @@
 package com.example.ruteplanlegger.Service
 
+import com.example.ruteplanlegger.Model.Geometri
+import com.example.ruteplanlegger.Model.LatLong
 import com.example.ruteplanlegger.Model.Rasteplass
 import com.fasterxml.jackson.databind.JsonNode
+import org.locationtech.jts.geom.Geometry
+import org.locationtech.jts.io.WKTReader
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 
+fun createGeometri(geometri: JsonNode): Geometri {
+    val wktNode = geometri["wkt"]
+    val wkt = wktNode.asText()
+    val wktReader = WKTReader()
+    val geometry: Geometry = wktReader.read(wkt)
+    val centroid =
+        geometry.centroid //gir et Point som er ca. i midten av en Linestring/Polygon
+    val lat: Double = centroid.coordinate.y
+    val long: Double = centroid.coordinate.x
+    val latLongObject = LatLong(long, lat)
+
+    return Geometri(type = "Point", coordinates = latLongObject)
+}
 
 fun createMinimalResteplassObject(data: JsonNode): List<Rasteplass> {
     return data["objekter"].map { rasteplass ->
+
         val id = rasteplass["id"].asInt()
         val navn = rasteplass["egenskaper"]
             .find { it["id"].asInt() == 1074 }
@@ -29,8 +47,9 @@ fun createMinimalResteplassObject(data: JsonNode): List<Rasteplass> {
             ?.asInt()
             ?: 0
 
+        val geometry = createGeometri(rasteplass["geometri"])
 
-        Rasteplass(id = id, navn = navn, vegkategori = vegkategori, vegnummer = vegnummer)
+        Rasteplass(id = id, navn = navn, vegkategori = vegkategori, vegnummer = vegnummer, geometri = geometry)
     }
 }
 


### PR DESCRIPTION
Vi har oppdatert endepunktet til å ta i mot geometri fra SVV. Vi konverterer geometrien fra SVV, som er på WKT-form, til latitude og longitude ved bruk av en WKTReader. Koordinatene + typen blir lagt til på datamodellen for Rasteplass som et Gemoetri-objekt. 

Polygon og linestring er gjort om til et POINT ved å hente "senteret" til polygonet og linestringen. 