### PR TITLE
Avgrense område med kartutsnitt for rasteplasser og kunst

### DIFF
--- a/src/main/kotlin/com/example/ruteplanlegger/model/Rasteplass.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Rasteplass.kt
@@ -7,7 +7,7 @@ data class Rasteplass(
     val vegkategori: String = "",
     val vegnummer: Int = 0,
     val geometri: Geometri,
-    val toalett: Boolean,
-    val utemobler: Boolean,
-    val lekeapparat: Boolean
+    val toalett: Boolean?,
+    val utemobler: Boolean?,
+    val lekeapparat: Boolean?
 )

--- a/src/main/kotlin/com/example/ruteplanlegger/service/KunstService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/KunstService.kt
@@ -47,7 +47,7 @@ fun createMinimalKunstObject(data: JsonNode): List<Kunst> {
 class KunstService(val webClient: WebClient.Builder) {
     fun getKunstOgUtsmykking(): List<Kunst>? {
         val apiURL =
-            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/19?antall=50&inkluder=egenskaper,vegsegmenter,geometri&inkluder_egenskaper=basis&egenskap=(1101!=null)&srid=4326"
+            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/19?kartutsnitt=8.0752408,61.4166883,11.027222,62.2085668&inkluder=egenskaper,vegsegmenter,geometri&inkluder_egenskaper=basis&egenskap=(1101!=null)&srid=4326"
         val response = webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
         return if (response is JsonNode) createMinimalKunstObject(response) else emptyList()
     }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/RasteplasserService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/RasteplasserService.kt
@@ -5,7 +5,6 @@ import com.example.ruteplanlegger.service.utils.createGeometri
 import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.util.UriComponentsBuilder
 
 fun createMinimalResteplassObject(data: JsonNode): List<Rasteplass> {
     val assosierteToalettanleggID = 220135
@@ -28,12 +27,6 @@ fun createMinimalResteplassObject(data: JsonNode): List<Rasteplass> {
 
         val geometry = createGeometri(rasteplass["geometri"])
 
-        val barn = rasteplass["relasjoner"]?.get("barn")
-
-
-
-
-
         val toalett = rasteplass["relasjoner"]?.get("barn")?.any { it["listeid"]?.asInt() == assosierteToalettanleggID }
         val utemobler = rasteplass["relasjoner"]?.get("barn")?.any { it["listeid"]?.asInt() == assosierteUtemoblerID }
         val lekeapparat = rasteplass["relasjoner"]?.get("barn")?.any { it["listeid"]?.asInt() == assosierteLekeapparatID }
@@ -55,17 +48,9 @@ fun createMinimalResteplassObject(data: JsonNode): List<Rasteplass> {
 @Service
 class RasteplasserService(val webClient: WebClient.Builder) {
     fun getAllRasteplasser(): List<Rasteplass>? {
-        val uri = UriComponentsBuilder
-            .fromUriString("https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39")
-            .queryParam("kartutsnitt", "8.0752408,61.4166883,11.027222,62.2085668")
-            .queryParam("inkluder", "vegsegmenter,egenskaper,geometri,relasjoner")
-            .queryParam("inkluder_egenskaper", "basis")
-            .queryParam("srid", "4326")
-            .toUriString()
-
-        // uri: https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39?kartutsnitt=8.0752408,61.4166883,11.027222,62.2085668&inkluder=vegsegmenter,egenskaper,geometri,relasjoner&inkluder_egenskaper=basis&srid=4326
-
-        val response = webClient.baseUrl(uri).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
+        val apiURL =
+            "https://nvdbapiles-v3.atlas.vegvesen.no/vegobjekter/39?kartutsnitt=8.0752408,61.4166883,11.027222,62.2085668&inkluder=vegsegmenter,egenskaper,geometri,relasjoner&inkluder_egenskaper=basis&srid=4326"
+        val response = webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
         return if (response is JsonNode) createMinimalResteplassObject(response) else emptyList()
     }
 }


### PR DESCRIPTION
Har skrevet litt på trello-kortet hva probletmed var (https://trello.com/c/6bzY2tt2/52-avgrense-et-omr%C3%A5de-i-kartet-ved-bruk-av-url), men kort sagt handlet det om at %-tegnet ble parset om til %25 fra springboot sin side. Det betyr at spring-boot endret litt på GET-requesten og dermed klarte ikke SVV å gi oss et svar tilbake.

Løsningen var egentlig bare å sende inn "hardkodet" koordinater, og ikke bruke de som vi fikk ut fra apiet til svv :))) TYP:

`kartutsnitt=8.0752408,61.4166883,11.027222,62.2085668`

sånn ser du ut i frontend: 

![image](https://github.com/bekk/ruteplanlegger-backend/assets/43408175/081f6024-4e13-4eeb-9727-603572d0bc44)
