### PR TITLE
Legge til beskrivelse + startLatLong på fotruter

### DIFF
--- a/src/main/kotlin/com/example/ruteplanlegger/model/Fotrute.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Fotrute.kt
@@ -11,5 +11,6 @@ data class Fotrute(
     val merking: Boolean = false,
     val skilting: Boolean = false,
     val gradering: String,
-    val anbefalt: Boolean = false
+    val anbefalt: Boolean = false,
+    val starLatLong: LatLong,
     )

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Fotrute.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Fotrute.kt
@@ -5,6 +5,7 @@ data class Fotrute(
     val id: Int = 0,
     val navn: String = "",
     val type: String = "Fotrute",
+    val beskrivelse: String,
     val lengde: Double = 0.0,
     val geometri: Any,
     val ruteFølger: List<String>,
@@ -12,5 +13,5 @@ data class Fotrute(
     val skilting: Boolean = false,
     val gradering: String,
     val anbefalt: Boolean = false,
-    val starLatLong: LatLong,
+    val startLatLong: LatLong,
     )

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Geometri.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Geometri.kt
@@ -8,8 +8,8 @@ data class Geometri(
 )
 
 data class LatLong(
-    val long: Double,
-    var lat: Double
+    var lat: Double,
+    val long: Double
 )
 
 data class GeoJSONGeometryCollection(

--- a/src/main/kotlin/com/example/ruteplanlegger/service/FotruteService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/FotruteService.kt
@@ -2,6 +2,7 @@ package com.example.ruteplanlegger.service
 
 import com.example.ruteplanlegger.model.Fotrute
 import com.example.ruteplanlegger.model.GeoJSONGeometryCollection
+import com.example.ruteplanlegger.model.LatLong
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.stereotype.Service
 
@@ -36,6 +37,7 @@ class FotruteService {
                 objectMapper.readValue(geometryJsonString, GeoJSONGeometryCollection::class.java)
 
             val anbefalt = id in recommendedFotruteList
+            val startLatLongk = LatLong(record["startLat"].toDouble(), record["startLong"].toDouble())
 
             val fotrute = Fotrute(
                 id = id,
@@ -46,7 +48,8 @@ class FotruteService {
                 merking = merking,
                 skilting = skilting,
                 gradering = gradering,
-                anbefalt = anbefalt
+                anbefalt = anbefalt,
+                starLatLong = startLatLongk
             )
             listofFotruter.add(fotrute)
         }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/FotruteService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/FotruteService.kt
@@ -25,8 +25,11 @@ class FotruteService {
             val id = record["id"].toInt()
             val navn = record["rutenavn"]
             val lengde = record["meter"].toDouble()
+            val beskrivelse = record["beskrivelse"]
+
             val ruteFølgerString = record["ruteFølger"].toString().replace("[", "").replace("]", "").replace("'", "")
             val ruteFølger = ruteFølgerString.split(", ")
+
             val merking = record["merking"].toBoolean()
             val skilting = record["skilting"].toBoolean()
             val gradering = record["gradering"]
@@ -37,11 +40,12 @@ class FotruteService {
                 objectMapper.readValue(geometryJsonString, GeoJSONGeometryCollection::class.java)
 
             val anbefalt = id in recommendedFotruteList
-            val startLatLongk = LatLong(record["startLat"].toDouble(), record["startLong"].toDouble())
+            val startLatLong = LatLong(record["startLat"].toDouble(), record["startLong"].toDouble())
 
             val fotrute = Fotrute(
                 id = id,
                 navn = navn,
+                beskrivelse = beskrivelse,
                 geometri = geoJSONFeatureCollection,
                 lengde = lengde,
                 ruteFølger = ruteFølger,
@@ -49,7 +53,7 @@ class FotruteService {
                 skilting = skilting,
                 gradering = gradering,
                 anbefalt = anbefalt,
-                starLatLong = startLatLongk
+                startLatLong = startLatLong
             )
             listofFotruter.add(fotrute)
         }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/utils/transformGeometryUtils.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/utils/transformGeometryUtils.kt
@@ -14,9 +14,9 @@ fun createGeometri(geometri: JsonNode): Geometri {
     val geometry: Geometry = wktReader.read(wkt)
     val centroid =
         geometry.centroid //gir et Point som er ca. i midten av en Linestring/Polygon
-    val lat: Double = centroid.coordinate.y
-    val long: Double = centroid.coordinate.x
-    val latLongObject = LatLong(long, lat)
+    val lat: Double = centroid.coordinate.x
+    val long: Double = centroid.coordinate.y
+    val latLongObject = LatLong(lat, long)
 
     return Geometri(type = "Point", coordinates = latLongObject)
 }


### PR DESCRIPTION
Har i tillegg fikset slik at koordinatene er på riktig form (at lat har det største nummeret, og long det minste). GeoJSON objektet er ikke noe endret på med tanke på lat-long, men dette har ikke vi satt selv (gjøres automatisk når vi konverterer til geojson), så dette skal gå fint med tanke på kartet. 

![image](https://github.com/bekk/ruteplanlegger-backend/assets/43408175/c3ab8d00-d3e3-483c-a937-e8ec28bbb687)
![image](https://github.com/bekk/ruteplanlegger-backend/assets/43408175/54abc248-60e3-470a-9576-5e17df7a55af)


Det var sånn her: 
![image](https://github.com/bekk/ruteplanlegger-backend/assets/43408175/da39ef24-06d6-4aa5-97e7-536920709f1c)

