### PR TITLE
Hente ut kjørerute i backend fra SVV

### DIFF
--- a/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
@@ -11,11 +11,6 @@ import org.springframework.web.bind.annotation.*
 
 class KjoreruteController(val kjoreruteService: KjoreruteService) {
 
-    @GetMapping("/oslo-hamar")
-    fun getKjoreruteOsloHamar():  Kjorerute? {
-        return kjoreruteService.getKjoreruteOsloHamar()
-    }
-
     @GetMapping
     fun getKjoreruter(@RequestParam start: List<Double>, @RequestParam slutt: List<Double>):  Kjorerute? {
         return kjoreruteService.getKjoreruter(start, slutt)

--- a/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
@@ -1,0 +1,18 @@
+package com.example.ruteplanlegger.controller
+
+import com.example.ruteplanlegger.model.Kjorerute
+import com.example.ruteplanlegger.service.KjoreruteService
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/kjoreruter")
+@CrossOrigin(origins = ["*"])
+
+class KjoreruteController(val kjoreruteService: KjoreruteService) {
+
+    @GetMapping
+    fun getFotruter(@RequestParam(required = false) anbefalt: Boolean):  List<Kjorerute>? {
+        return kjoreruteService.getKjoreruteOsloHamar()
+    }
+
+}

--- a/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
@@ -11,9 +11,14 @@ import org.springframework.web.bind.annotation.*
 
 class KjoreruteController(val kjoreruteService: KjoreruteService) {
 
-    @GetMapping
-    fun getFotruter(@RequestParam start: List<Double>, @RequestParam slutt: List<Double>):  List<Kjorerute>? {
+    @GetMapping("/oslo-hamar")
+    fun getKjoreruteOsloHamar():  Kjorerute? {
         return kjoreruteService.getKjoreruteOsloHamar()
+    }
+
+    @GetMapping
+    fun getKjoreruter(@RequestParam start: List<Double>, @RequestParam slutt: List<Double>):  Kjorerute? {
+        return kjoreruteService.getKjoreruter(start, slutt)
     }
 
 }

--- a/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/KjoreruteController.kt
@@ -1,6 +1,7 @@
 package com.example.ruteplanlegger.controller
 
 import com.example.ruteplanlegger.model.Kjorerute
+import com.example.ruteplanlegger.model.LatLong
 import com.example.ruteplanlegger.service.KjoreruteService
 import org.springframework.web.bind.annotation.*
 
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.*
 class KjoreruteController(val kjoreruteService: KjoreruteService) {
 
     @GetMapping
-    fun getFotruter(@RequestParam(required = false) anbefalt: Boolean):  List<Kjorerute>? {
+    fun getFotruter(@RequestParam start: List<Double>, @RequestParam slutt: List<Double>):  List<Kjorerute>? {
         return kjoreruteService.getKjoreruteOsloHamar()
     }
 

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Geometri.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Geometri.kt
@@ -1,6 +1,7 @@
 package com.example.ruteplanlegger.model
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.JsonNode
 
 data class Geometri(
     val type: String = "Point",
@@ -10,6 +11,11 @@ data class Geometri(
 data class LatLong(
     var lat: Double,
     val long: Double
+)
+
+data class GeoJSONFeatureCollection(
+    @JsonProperty("type") val type: String,
+    @JsonProperty("features") val features: JsonNode
 )
 
 data class GeoJSONGeometryCollection(

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Kjorerute.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Kjorerute.kt
@@ -3,8 +3,9 @@ package com.example.ruteplanlegger.model
 data class Kjorerute(
     val id: String = "",
     val routeName: String = "",
-    val totalDriveTime: Double = 0.0,
-    val totalTime: Double = 0.0, // hva er forskjellen på denne og den over?
+    val totalDriveTime: Double = 0.0, // total drive time of the route, given in minutes (with delays if supported)
+    val totalTime: Double = 0.0, // total time of the route. will mostly be equal to totalDriveTime,
+    // but if delays or certain waiting time restrictions are supported, this will be summarized in totalDriveTime
     val totalLength: Double = 0.0,
     val geojson: GeoJSONFeatureCollection
 )

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Kjorerute.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Kjorerute.kt
@@ -1,0 +1,10 @@
+package com.example.ruteplanlegger.model
+
+data class Kjorerute(
+    val id: String = "",
+    val routeName: String = "",
+    val totalDriveTime: Double = 0.0,
+    val totalTime: Double = 0.0, // hva er forskjellen på denne og den over?
+    val totalLength: Double = 0.0,
+    val geojson: GeoJSONFeatureCollection
+)

--- a/src/main/kotlin/com/example/ruteplanlegger/service/KjoreruteService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/KjoreruteService.kt
@@ -34,21 +34,11 @@ fun createMinimalKjorerute(data: JsonNode): Kjorerute {
 
 @Service
 class KjoreruteService(val webClient: WebClient.Builder) {
-    fun getKjoreruteOsloHamar(): Kjorerute? {
-        // %2C er det samme som ,
-        // %3B er det samme som ;
-        val apiURL =
-            "https://www.vegvesen.no/ws/no/vegvesen/ruteplan/routingservice_v3_0/open/routingService/api/Route/best?Stops=10.73353,59.91187;10.39506,63.43048&InputSRS=EPSG_4326&OutputSRS=EPSG_4326&ReturnFields=Geometry"
-        val response = webClient.baseUrl(apiURL).codecs { it.defaultCodecs().maxInMemorySize(2000 * 1024) }
-            .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, deflate").build().get().retrieve()
-            .bodyToMono(JsonNode::class.java).block()
-
-        return if (response is JsonNode) createMinimalKjorerute(response) else null
-    }
 
     fun getKjoreruter(start: List<Double>, slutt: List<Double>): Kjorerute? {
-        // Test: http://localhost:8080/kjoreruter?start=59.91187,10.73353&slutt=63.43048,10.39506 //oslo - trondheim
-        // https://www.vegvesen.no/ws/no/vegvesen/ruteplan/routingservice_v3_0/open/routingService/api/Route/best?Stops=10.73353,59.91187;10.39506,63.43048&InputSRS=EPSG_4326&OutputSRS=EPSG_4326&ReturnFields=Geometry&StartTime=20231016132012
+        // %2C er det samme som ,
+        // %3B er det samme som ;
+        // Test: http://localhost:8080/kjoreruter?start=59.91187,10.73353&slutt=63.43048,10.39506 // oslo - trondheim
         val startLat = start[0]
         val startLong = start[1]
         val sluttLat = slutt[0]
@@ -56,12 +46,9 @@ class KjoreruteService(val webClient: WebClient.Builder) {
 
         val apiURL =
             "https://www.vegvesen.no/ws/no/vegvesen/ruteplan/routingservice_v3_0/open/routingService/api/Route/best?Stops=$startLong,$startLat;$sluttLong,$sluttLat&InputSRS=EPSG_4326&OutputSRS=EPSG_4326&ReturnFields=Geometry"
-        val response = webClient.baseUrl(apiURL).codecs { it.defaultCodecs().maxInMemorySize(2000 * 1024) }
+        val response = webClient.baseUrl(apiURL).codecs { it.defaultCodecs().maxInMemorySize(1300 * 1024) }
             .defaultHeader(HttpHeaders.ACCEPT_ENCODING, "gzip, deflate").build().get().retrieve()
             .bodyToMono(JsonNode::class.java).block()
-
-        val contentLength = response?.size()
-        println(contentLength)
 
         return if (response is JsonNode) createMinimalKjorerute(response) else null
     }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/KjoreruteService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/KjoreruteService.kt
@@ -1,0 +1,44 @@
+package com.example.ruteplanlegger.service
+
+import com.example.ruteplanlegger.model.GeoJSONFeatureCollection
+import com.example.ruteplanlegger.model.Kjorerute
+import com.fasterxml.jackson.databind.JsonNode
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+
+fun createMinimalKjorerute(data: JsonNode): List<Kjorerute> {
+    return data["routes"].map { kjorerute ->
+        val id = kjorerute["routeId"].asText()
+        val routeName = kjorerute["routeName"].asText()
+
+        val totalDriveTime = kjorerute["statistic"].get("totalDriveTime").asDouble()
+        val totalTime = kjorerute["statistic"].get("totalTime").asDouble()
+        val totalLength = kjorerute["statistic"].get("totalLength").asDouble()
+
+        val features = kjorerute["features"]
+        val geoJSON = GeoJSONFeatureCollection("FeatureCollection", features)
+
+        Kjorerute(
+            id = id,
+            routeName = routeName,
+            totalDriveTime = totalDriveTime,
+            totalTime = totalTime,
+            totalLength = totalLength,
+            geojson = geoJSON
+        )
+    }
+}
+
+@Service
+class KjoreruteService(val webClient: WebClient.Builder) {
+    fun getKjoreruteOsloHamar(): List<Kjorerute>? {
+        // %2C er det samme som ,
+        // %3B er det samme som ;
+        val apiURL =
+            "https://www.vegvesen.no/ws/no/vegvesen/ruteplan/routingservice_v3_0/open/routingService/api/Route/best?Stops=10.74609,59.91273;11.06798,60.7945&InputSRS=EPSG_4326&OutputSRS=EPSG_4326&ReturnFields=Geometry"
+        val response = webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
+
+        return if (response is JsonNode) createMinimalKjorerute(response) else emptyList()
+    }
+}


### PR DESCRIPTION
codecs gjøre at vi kan øke hvor mye springboot kan hente av data. Vi måtte øke denne, om ikke klarte ikke backenden vår å hente ut alt fra SVV. Vi sender kun den første ruten til frontend pr nå. 