### PR TITLE
Vegbilder kall m feilhåndtering

### DIFF
--- a/src/main/kotlin/com/example/ruteplanlegger/controller/VegbildeController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/VegbildeController.kt
@@ -1,0 +1,31 @@
+package com.example.ruteplanlegger.controller
+
+
+
+import com.example.ruteplanlegger.model.VegBilde
+import com.example.ruteplanlegger.service.VegbildeService
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import reactor.core.publisher.Mono
+import java.lang.Exception
+
+
+@RestController
+@RequestMapping("/vegbilde")
+@CrossOrigin(origins = ["*"])
+class VegbildeController(private val vegbildeService: VegbildeService) {
+
+    @GetMapping("/{bbox}")
+    fun getVegbilde(@PathVariable bbox: String): Any {
+        try {
+            val vegbilde = vegbildeService.getVegbilde(bbox)
+            return ResponseEntity.ok(vegbilde)
+
+        }
+        catch (ex: Exception) {
+            print(ex)
+            return ResponseEntity.notFound()
+        }
+    }
+}

--- a/src/main/kotlin/com/example/ruteplanlegger/controller/VegbildeController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/VegbildeController.kt
@@ -17,15 +17,14 @@ import java.lang.Exception
 class VegbildeController(private val vegbildeService: VegbildeService) {
 
     @GetMapping("/{bbox}")
-    fun getVegbilde(@PathVariable bbox: String): Any {
+    fun getVegbilde(@PathVariable bbox: String): ResponseEntity<List<VegBilde>> {
         try {
             val vegbilde = vegbildeService.getVegbilde(bbox)
             return ResponseEntity.ok(vegbilde)
 
         }
         catch (ex: Exception) {
-            print(ex)
-            return ResponseEntity.notFound()
+            return ResponseEntity.badRequest().build()
         }
     }
 }

--- a/src/main/kotlin/com/example/ruteplanlegger/controller/VegbildeController.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/controller/VegbildeController.kt
@@ -4,11 +4,10 @@ package com.example.ruteplanlegger.controller
 
 import com.example.ruteplanlegger.model.VegBilde
 import com.example.ruteplanlegger.service.VegbildeService
-import org.springframework.http.HttpStatus
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
-import reactor.core.publisher.Mono
-import java.lang.Exception
 
 
 @RestController

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Stedsnavn.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Stedsnavn.kt
@@ -1,5 +1,7 @@
 package com.example.ruteplanlegger.model
 
+import com.fasterxml.jackson.annotation.JsonProperty
+
 data class Stedsnavn (
     val navn: String,
     val id: Int = 0,

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Vegbilde.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Vegbilde.kt
@@ -1,6 +1,4 @@
 package com.example.ruteplanlegger.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
-
 
 data class VegBilde( val URL: String)

--- a/src/main/kotlin/com/example/ruteplanlegger/model/VegbildeApiResponse.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/VegbildeApiResponse.kt
@@ -1,0 +1,6 @@
+package com.example.ruteplanlegger.model
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+
+data class VegBilde( val URL: String)

--- a/src/main/kotlin/com/example/ruteplanlegger/service/VegbildeService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/VegbildeService.kt
@@ -1,0 +1,41 @@
+package com.example.ruteplanlegger.service
+
+import com.example.ruteplanlegger.model.*
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+import java.io.IOException
+
+
+@Service
+class VegbildeService(val webClient: WebClient.Builder) {
+
+    public fun getVegbilde(bbox: String): List<Any> {
+
+        val objectMapper = ObjectMapper()
+        val vegbildeURL =
+            "https://ogckart-sn1.atlas.vegvesen.no/vegbilder_1_0/ows?service=WFS&version=2.0.0&request=GetFeature&typenames=vegbilder_1_0:Vegbilder_2023&startindex=0&count=10&srsname=urn:ogc:def:crs:EPSG::4326&bbox=${bbox},urn:ogc:def:crs:EPSG:4326&outputformat=application/json"
+        val listofVegBilder = mutableListOf<Any>()
+
+        val response = webClient.baseUrl(vegbildeURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
+
+        if (response is JsonNode) {
+
+           response.get("features").map { bilde ->
+
+                            println(bilde["properties"])
+                            //val geometri = bilde["geometri"].get("coordinates")
+                            val url = bilde["properties"].get("URL")
+                            val vegBilde = VegBilde( URL = url.textValue())
+                            println(vegBilde)
+                            listofVegBilder.add(vegBilde)
+            }
+
+            return listofVegBilder
+
+
+        }
+        throw Exception("Couldnt get vegbilder from API")
+    }
+}

--- a/src/main/kotlin/com/example/ruteplanlegger/service/VegbildeService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/VegbildeService.kt
@@ -45,13 +45,9 @@ class VegbildeService(val webClient: WebClient.Builder) {
         val listofVegBilder = mutableListOf<VegBilde>()
 
         try {
-            response.get("features").map { bilde ->
-
-                val url = bilde["properties"].get("URL")
-                val vegBilde = VegBilde(URL = url.textValue())
-                listofVegBilder.add(vegBilde)
-            }
-
+            val url = response.get("features")[0]["properties"].get("URL")
+            val vegBilde = VegBilde(URL = url.textValue())
+            listofVegBilder.add(vegBilde)
             if (listofVegBilder.isEmpty()) {
                 throw IllegalStateException("List is empty")
             }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,4 @@
-
+//show error and debug logs in console
+logging.level.=TRACE
+//Enable colors in logging
+spring.output.ansi.enabled=always


### PR DESCRIPTION
Kall mot SVV API-et skjer i backend nå - med controller, service og model (som kun har et URL felt til nå)

har også implementert en logger, som logger feilmeldinger i konsollen for vegbilde-flyten


... Jeg vet egt ikke hva som er "best-practice" ang feilhåndtering og hvor man skal ha de + hvordan man best gjør det.. Håper det som er gjort er et lite steg i riktig retning i hvert fall, men tenker å lage et nytt kort på det som kan undersøke og implementere sånt bedre 🤔 💭 
Slik ser det ut med logging når noe feil oppstår med å hente vegbilder:
<img width="1595" alt="Screenshot 2023-10-20 at 10 31 20" src="https://github.com/bekk/ruteplanlegger-backend/assets/74315929/a48e00be-4fd4-4680-919a-832eb76da639">

<img width="1567" alt="Screenshot 2023-10-20 at 10 30 48" src="https://github.com/bekk/ruteplanlegger-backend/assets/74315929/725044c6-873c-4117-a63c-c7b4eae23401">
