### PR TITLE
Legge til adresse API i stedsnavn-søk

### DIFF
--- a/src/main/kotlin/com/example/ruteplanlegger/RuteplanleggerApplication.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/RuteplanleggerApplication.kt
@@ -1,8 +1,5 @@
 package com.example.ruteplanlegger
 
-import org.jetbrains.kotlinx.dataframe.DataFrame
-import org.jetbrains.kotlinx.dataframe.api.print
-import org.jetbrains.kotlinx.dataframe.io.read
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 

--- a/src/main/kotlin/com/example/ruteplanlegger/model/Stedsnavn.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/model/Stedsnavn.kt
@@ -1,10 +1,10 @@
 package com.example.ruteplanlegger.model
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import java.util.UUID
 
 data class Stedsnavn (
     val navn: String,
-    val id: Int = 0,
+    val id: UUID = UUID.randomUUID(),
     val typeObjekt: String,
     val koordinat: LatLong,
 )

--- a/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
@@ -3,42 +3,56 @@ package com.example.ruteplanlegger.service
 import com.example.ruteplanlegger.model.LatLong
 import com.example.ruteplanlegger.model.Stedsnavn
 import com.fasterxml.jackson.databind.JsonNode
+import org.springframework.stereotype.Component
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 
-fun createStedsnavnObjectFromStedsnavnAPI(data: JsonNode) = data["navn"].map { sted ->
-    val navn = sted["skrivemåte"].asText()
-    val type = sted["navneobjekttype"].asText()
-    val lat = sted["representasjonspunkt"]["nord"].asDouble()
-    val long = sted["representasjonspunkt"]["øst"].asDouble()
-    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long))
-
-}
-
-fun createStedsnavnObjectFromAdresserAPI(data: JsonNode) = data["adresser"].map { adresse ->
-    val navn = adresse["adressetekst"].asText()
-    val type = adresse["objtype"].asText()
-    val lat = adresse["representasjonspunkt"]["lat"].asDouble()
-    val long = adresse["representasjonspunkt"]["lon"].asDouble()
-    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long))
-}
-
 @Service
-class StedsnavnService(val webClient: WebClient.Builder) {
-    fun getStedsnavn(query: String): List<Stedsnavn>? {
+class ApiService(val webClient: WebClient.Builder) {
+    fun getStedsnavnDataFromAPI(query: String): JsonNode? {
         val stedsnavnApiURL =
             "https://ws.geonorge.no/stedsnavn/v1/navn?sok=$query&fuzzy=true&&maxAnt=10&antPerSide=10&eksakteForst=true"
         val stedsnavnResponse =
             webClient.baseUrl(stedsnavnApiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
-
+        return stedsnavnResponse
+    }
+    fun getAdresseDataFromAPI(query: String): JsonNode? {
         val adresseApiURL =
             "https://ws.geonorge.no/adresser/v1/sok?sok=$query&fuzzy=true&treffPerSide=10&asciiKompatibel=true"
         val adresseResponse =
             webClient.baseUrl(adresseApiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
+        return adresseResponse
+    }
+}
 
-        val stedsnavnList = if (stedsnavnResponse is JsonNode) createStedsnavnObjectFromStedsnavnAPI(stedsnavnResponse) else emptyList()
+@Component
+class StedsnavnParser {
+    fun parseStedsnavnFromStedsnavnAPI(data: JsonNode) = data["navn"].map { sted ->
+        val navn = sted["skrivemåte"].asText()
+        val type = sted["navneobjekttype"].asText()
+        val lat = sted["representasjonspunkt"]["nord"].asDouble()
+        val long = sted["representasjonspunkt"]["øst"].asDouble()
+        Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long))
+    }
+
+    fun parseStedsnavnFromAdresserAPI(data: JsonNode) = data["adresser"].map { adresse ->
+        val navn = adresse["adressetekst"].asText()
+        val type = adresse["objtype"].asText()
+        val lat = adresse["representasjonspunkt"]["lat"].asDouble()
+        val long = adresse["representasjonspunkt"]["lon"].asDouble()
+        Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long))
+    }
+}
+
+@Service
+class StedsnavnService(val apiService: ApiService, val stedsnavnParser: StedsnavnParser) {
+    fun getStedsnavn(query: String): List<Stedsnavn>? {
+        val stedsnavnResponse = apiService.getStedsnavnDataFromAPI(query)
+        val adresseResponse = apiService.getAdresseDataFromAPI(query)
+
+        val stedsnavnList = if (stedsnavnResponse is JsonNode) stedsnavnParser.parseStedsnavnFromStedsnavnAPI(stedsnavnResponse) else emptyList()
         val adresseList =
-            if (adresseResponse is JsonNode) createStedsnavnObjectFromAdresserAPI(adresseResponse) else emptyList()
+            if (adresseResponse is JsonNode) stedsnavnParser.parseStedsnavnFromAdresserAPI(adresseResponse) else emptyList()
 
         return stedsnavnList + adresseList
     }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
@@ -6,15 +6,12 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 
-var index = -1;
-
 fun createStedsnavnObjectFromStedsnavnAPI(data: JsonNode) = data["navn"].map { sted ->
     val navn = sted["skrivemåte"].asText()
     val type = sted["navneobjekttype"].asText()
     val lat = sted["representasjonspunkt"]["nord"].asDouble()
     val long = sted["representasjonspunkt"]["øst"].asDouble()
-    index++
-    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long), id = index)
+    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long))
 
 }
 
@@ -23,8 +20,7 @@ fun createStedsnavnObjectFromAdresserAPI(data: JsonNode) = data["adresser"].map 
     val type = adresse["objtype"].asText()
     val lat = adresse["representasjonspunkt"]["lat"].asDouble()
     val long = adresse["representasjonspunkt"]["lon"].asDouble()
-    index++
-    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long), id = index)
+    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long))
 }
 
 @Service

--- a/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
@@ -8,7 +8,7 @@ import org.springframework.web.reactive.function.client.WebClient
 
 var index = -1;
 
-fun createStedsnavnObject(data: JsonNode) = data["navn"].map { sted ->
+fun createStedsnavnObjectFromStedsnavnAPI(data: JsonNode) = data["navn"].map { sted ->
     val navn = sted["skrivemåte"].asText()
     val type = sted["navneobjekttype"].asText()
     val lat = sted["representasjonspunkt"]["nord"].asDouble()
@@ -18,7 +18,7 @@ fun createStedsnavnObject(data: JsonNode) = data["navn"].map { sted ->
 
 }
 
-fun createStedsnavnObjectFromAdresser(data: JsonNode) = data["adresser"].map { adresse ->
+fun createStedsnavnObjectFromAdresserAPI(data: JsonNode) = data["adresser"].map { adresse ->
     val navn = adresse["adressetekst"].asText()
     val type = adresse["objtype"].asText()
     val lat = adresse["representasjonspunkt"]["lat"].asDouble()
@@ -40,9 +40,9 @@ class StedsnavnService(val webClient: WebClient.Builder) {
         val adresseResponse =
             webClient.baseUrl(adresseApiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
 
-        val stedsnavnList = if (stedsnavnResponse is JsonNode) createStedsnavnObject(stedsnavnResponse) else emptyList()
+        val stedsnavnList = if (stedsnavnResponse is JsonNode) createStedsnavnObjectFromStedsnavnAPI(stedsnavnResponse) else emptyList()
         val adresseList =
-            if (adresseResponse is JsonNode) createStedsnavnObjectFromAdresser(adresseResponse) else emptyList()
+            if (adresseResponse is JsonNode) createStedsnavnObjectFromAdresserAPI(adresseResponse) else emptyList()
 
         return stedsnavnList + adresseList
     }

--- a/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
@@ -16,6 +16,7 @@ class ApiService(val webClient: WebClient.Builder) {
             webClient.baseUrl(stedsnavnApiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
         return stedsnavnResponse
     }
+
     fun getAdresseDataFromAPI(query: String): JsonNode? {
         val adresseApiURL =
             "https://ws.geonorge.no/adresser/v1/sok?sok=$query&fuzzy=true&treffPerSide=10&asciiKompatibel=true"
@@ -50,7 +51,8 @@ class StedsnavnService(val apiService: ApiService, val stedsnavnParser: Stedsnav
         val stedsnavnResponse = apiService.getStedsnavnDataFromAPI(query)
         val adresseResponse = apiService.getAdresseDataFromAPI(query)
 
-        val stedsnavnList = if (stedsnavnResponse is JsonNode) stedsnavnParser.parseStedsnavnFromStedsnavnAPI(stedsnavnResponse) else emptyList()
+        val stedsnavnList =
+            if (stedsnavnResponse is JsonNode) stedsnavnParser.parseStedsnavnFromStedsnavnAPI(stedsnavnResponse) else emptyList()
         val adresseList =
             if (adresseResponse is JsonNode) stedsnavnParser.parseStedsnavnFromAdresserAPI(adresseResponse) else emptyList()
 

--- a/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
+++ b/src/main/kotlin/com/example/ruteplanlegger/service/StedsnavnService.kt
@@ -6,22 +6,44 @@ import com.fasterxml.jackson.databind.JsonNode
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
 
+var index = -1;
 
-fun createStedsnavnObject(data: JsonNode) : List<Stedsnavn> {
-    return data["navn"].mapIndexed {index, sted ->
-        val navn = sted["skrivemåte"].asText()
-        val type = sted["navneobjekttype"].asText()
-        val lat = sted["representasjonspunkt"]["nord"].asDouble()
-        val long = sted["representasjonspunkt"]["øst"].asDouble()
-        Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long), id = index) }
-
+fun createStedsnavnObject(data: JsonNode) = data["navn"].map { sted ->
+    val navn = sted["skrivemåte"].asText()
+    val type = sted["navneobjekttype"].asText()
+    val lat = sted["representasjonspunkt"]["nord"].asDouble()
+    val long = sted["representasjonspunkt"]["øst"].asDouble()
+    index++
+    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long), id = index)
 
 }
+
+fun createStedsnavnObjectFromAdresser(data: JsonNode) = data["adresser"].map { adresse ->
+    val navn = adresse["adressetekst"].asText()
+    val type = adresse["objtype"].asText()
+    val lat = adresse["representasjonspunkt"]["lat"].asDouble()
+    val long = adresse["representasjonspunkt"]["lon"].asDouble()
+    index++
+    Stedsnavn(navn = navn, typeObjekt = type, koordinat = LatLong(lat, long), id = index)
+}
+
 @Service
-class StedsnavnService (val webClient: WebClient.Builder){
-    fun getStedsnavn(query: String): List<Stedsnavn>?{
-        val apiURL = "https://ws.geonorge.no/stedsnavn/v1/navn?sok=$query*&maxAnt=10&antPerSide=10&eksakteForst=true"
-        val response = webClient.baseUrl(apiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
-        return if (response is JsonNode) createStedsnavnObject(response) else emptyList()
+class StedsnavnService(val webClient: WebClient.Builder) {
+    fun getStedsnavn(query: String): List<Stedsnavn>? {
+        val stedsnavnApiURL =
+            "https://ws.geonorge.no/stedsnavn/v1/navn?sok=$query&fuzzy=true&&maxAnt=10&antPerSide=10&eksakteForst=true"
+        val stedsnavnResponse =
+            webClient.baseUrl(stedsnavnApiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
+
+        val adresseApiURL =
+            "https://ws.geonorge.no/adresser/v1/sok?sok=$query&fuzzy=true&treffPerSide=10&asciiKompatibel=true"
+        val adresseResponse =
+            webClient.baseUrl(adresseApiURL).build().get().retrieve().bodyToMono(JsonNode::class.java).block()
+
+        val stedsnavnList = if (stedsnavnResponse is JsonNode) createStedsnavnObject(stedsnavnResponse) else emptyList()
+        val adresseList =
+            if (adresseResponse is JsonNode) createStedsnavnObjectFromAdresser(adresseResponse) else emptyList()
+
+        return stedsnavnList + adresseList
     }
 }


### PR DESCRIPTION
Lagt til fuzzy-søk på begge. Fra getStedsnavn) returneres både stedsnavn-responsen og adresse-responsen. 
Forskjellen kan sees at typen er "Adressenavn" om det kommer fra stedsnavn-apiet, og "Vegadresse" om det kommer fra adresse-apiet. 

![image](https://github.com/bekk/ruteplanlegger-backend/assets/43408175/32b97cb7-8557-4f14-90a8-5e2e4a65372c)
